### PR TITLE
fix for IE 11

### DIFF
--- a/NuGet/HotTowel-NG/app/services/directives.js
+++ b/NuGet/HotTowel-NG/app/services/directives.js
@@ -146,7 +146,7 @@
                     e.preventDefault();
                     // Learning Point: $anchorScroll works, but no animation
                     //$anchorScroll();
-                    $('body').animate({ scrollTop: 0 }, 500);
+                    $('html, body').animate({ scrollTop: 0 }, 500);
                 });
 
                 function toggleIcon() {


### PR DESCRIPTION
While running on my machine, Windows 7 64-bit, IE11, the scroll to the top "button" doesn't work. This change fixes it.
